### PR TITLE
Use https jQuery location

### DIFF
--- a/source/template.php
+++ b/source/template.php
@@ -159,7 +159,7 @@ include "page/$page.php";
 
 <!-- ******** javascript includes ******** -->
 
-<script src="http://code.jquery.com/jquery.js"></script>
+<script src="https://code.jquery.com/jquery.js"></script>
 <script src="/assets/bootstrap/js/bootstrap.min.js"></script>
 <script type="text/javascript" src="https://apis.google.com/js/platform.js"></script>
 


### PR DESCRIPTION
Currently, accessing https://iitc.me blocks the jQuery load due to [mixed content restrictions](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content).
